### PR TITLE
fix: Correct package name in import statements

### DIFF
--- a/lib/screens/add_trip_screen.dart
+++ b/lib/screens/add_trip_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:our_go/models/new_trip.dart';
-import 'package:our_go/services/api_service.dart';
+import 'package:ourgo_app/models/new_trip.dart';
+import 'package:ourgo_app/services/api_service.dart';
 
 class AddTripScreen extends StatefulWidget {
   final VoidCallback onTripAdded;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:our_go/screens/add_trip_screen.dart';
-import 'package:our_go/widgets/trip_list.dart';
+import 'package:ourgo_app/screens/add_trip_screen.dart';
+import 'package:ourgo_app/widgets/trip_list.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
-import 'package:our_go/models/new_trip.dart';
-import 'package:our_go/models/trip.dart';
+import 'package:ourgo_app/models/new_trip.dart';
+import 'package:ourgo_app/models/trip.dart';
 
 class ApiService {
   // Base URL of the API. This would be a real URL in a production app.

--- a/lib/widgets/trip_list.dart
+++ b/lib/widgets/trip_list.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:our_go/models/trip.dart';
-import 'package:our_go/services/api_service.dart';
+import 'package:ourgo_app/models/trip.dart';
+import 'package:ourgo_app/services/api_service.dart';
 
 class TripList extends StatefulWidget {
   const TripList({super.key});

--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:our_go/models/new_trip.dart';
-import 'package:our_go/services/api_service.dart';
+import 'package:ourgo_app/models/new_trip.dart';
+import 'package:ourgo_app/services/api_service.dart';
 
 void main() {
   group('ApiService', () {


### PR DESCRIPTION
This commit fixes a build error caused by using an incorrect package name in the import statements. The package name was changed from `our_go` to `ourgo_app` to match the `pubspec.yaml` file.

This change affects the following files:
- `lib/screens/home_screen.dart`
- `lib/widgets/trip_list.dart`
- `lib/services/api_service.dart`
- `lib/screens/add_trip_screen.dart`
- `test/api_service_test.dart`